### PR TITLE
Remove objective rust dependency

### DIFF
--- a/plugins/scaffolding-ui/Cargo.toml
+++ b/plugins/scaffolding-ui/Cargo.toml
@@ -8,5 +8,5 @@ workspace = true
 default-features = false
 features = []
 
-[target.'cfg(os = "macos")'.dependencies]
-objective-rust.path = "../../../objective-rust"
+#[target.'cfg(os = "macos")'.dependencies]
+#objective-rust.path = "../../../objective-rust"


### PR DESCRIPTION
This PR removes a path dependency on the `objective-rust` crate