### PR TITLE
Add iterator implementations to Arenavec

### DIFF
--- a/scaffolding/src/datatypes/arenavec.rs
+++ b/scaffolding/src/datatypes/arenavec.rs
@@ -225,6 +225,27 @@ impl<T> ArenaVec<T> {
     pub fn buf_ptr_mut(&mut self) -> *mut T {
         self.buffer
     }
+
+    pub fn iter(&self) -> Iter<T> {
+        Iter {
+            arena_vec: self,
+            idx: 0,
+        }
+    }
+
+    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
+        IterMut {
+            arena_vec: self,
+            idx: 0,
+        }
+    }
+
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter {
+            arena_vec: self,
+            idx: 0,
+        }
+    }
 }
 impl<T> Default for ArenaVec<T> {
     fn default() -> Self {
@@ -289,12 +310,12 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-pub struct Itermut<'a, T> {
+pub struct IterMut<'a, T> {
     arena_vec: &'a mut ArenaVec<T>,
     idx: usize,
 }
 
-impl<'a, T> Iterator for Itermut<'a, T> {
+impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<Self::Item> {
         let idx = self.idx;

--- a/scaffolding/src/datatypes/arenavec.rs
+++ b/scaffolding/src/datatypes/arenavec.rs
@@ -219,10 +219,10 @@ impl<T> ArenaVec<T> {
         self.reserved_memory
     }
 
-    pub fn buf_ptr(&self) -> *const T {
+    pub fn as_ptr(&self) -> *const T {
         self.buffer as *const T
     }
-    pub fn buf_ptr_mut(&mut self) -> *mut T {
+    pub fn as_mut_ptr(&mut self) -> *mut T {
         self.buffer
     }
 
@@ -342,14 +342,7 @@ impl<T> Iterator for IntoIter<T> {
         }
         self.idx += 1;
         let ptr = self.arena_vec.buf_ptr_mut();
-        Some(unsafe {
-            // We can't use normal copying functions, since T isn't guaranteed to be copy
-            // Here, we instantiate a new instance of T, and copy the bytes
-            // This should be safe because we will never read the original T again, so it's fine that we technically copied the data
-            let mut new_t = std::mem::MaybeUninit::uninit();
-            std::ptr::copy(ptr.add(idx), new_t.as_mut_ptr(), 1);
-            new_t.assume_init()
-        })
+        Some(unsafe { ptr.add(idx).read() })
     }
 }
 

--- a/scaffolding/src/datatypes/arenavec.rs
+++ b/scaffolding/src/datatypes/arenavec.rs
@@ -423,6 +423,30 @@ mod tests {
     }
 
     #[test]
+    fn iter_mut_modify() {
+        let mut vec = ArenaVec::default();
+        vec.push(0);
+        vec.push(1);
+        vec.push(2);
+
+        let iter = vec.iter_mut();
+        let mut iter = iter.map(|num| {
+            *num += 1;
+            num
+        });
+        assert_eq!(iter.next(), Some(&mut 1));
+        assert_eq!(iter.next(), Some(&mut 2));
+        assert_eq!(iter.next(), Some(&mut 3));
+        assert_eq!(iter.next(), None);
+
+        drop(iter);
+        assert_eq!(*vec.get(0).unwrap(), 1);
+        assert_eq!(*vec.get(1).unwrap(), 2);
+        assert_eq!(*vec.get(2).unwrap(), 3);
+        assert_eq!(vec.get(3), None);
+    }
+
+    #[test]
     fn basic_into_iter() {
         let vec = ArenaVec::default();
         vec.push(0);

--- a/scaffolding/src/datatypes/arenavec.rs
+++ b/scaffolding/src/datatypes/arenavec.rs
@@ -381,4 +381,58 @@ mod tests {
         assert_eq!(*vec.get(1).unwrap(), 2);
         assert_eq!(vec.get(2), None);
     }
+
+    #[test]
+    fn basic_iter() {
+        let vec = ArenaVec::default();
+        vec.push(0);
+        vec.push(1);
+        vec.push(2);
+
+        let mut iter = vec.iter();
+        assert_eq!(iter.next(), Some(&0));
+        assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), Some(&2));
+        assert_eq!(iter.next(), None);
+
+        drop(iter);
+        assert_eq!(*vec.get(0).unwrap(), 0);
+        assert_eq!(*vec.get(1).unwrap(), 1);
+        assert_eq!(*vec.get(2).unwrap(), 2);
+        assert_eq!(vec.get(3), None);
+    }
+
+    #[test]
+    fn basic_iter_mut() {
+        let mut vec = ArenaVec::default();
+        vec.push(0);
+        vec.push(1);
+        vec.push(2);
+
+        let mut iter = vec.iter_mut();
+        assert_eq!(iter.next(), Some(&mut 0));
+        assert_eq!(iter.next(), Some(&mut 1));
+        assert_eq!(iter.next(), Some(&mut 2));
+        assert_eq!(iter.next(), None);
+
+        drop(iter);
+        assert_eq!(*vec.get(0).unwrap(), 0);
+        assert_eq!(*vec.get(1).unwrap(), 1);
+        assert_eq!(*vec.get(2).unwrap(), 2);
+        assert_eq!(vec.get(3), None);
+    }
+
+    #[test]
+    fn basic_into_iter() {
+        let vec = ArenaVec::default();
+        vec.push(0);
+        vec.push(1);
+        vec.push(2);
+
+        let mut iter = vec.into_iter();
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.next(), None);
+    }
 }


### PR DESCRIPTION
This PR adds implementations of the `Iterator` trait for `arenavec`. `arenavec` now supports the functions `iter()`, `iter_mut()`, and `into_iter()`, which provide different implementations of `Iterator`, corresponding to the type and mutability of the type. It also adds the public functions `buf_ptr()` and `buf_ptr_mut()` to `arenavec`, allowing outside code to read and mutate the raw pointer buffer. This was necessary for implementing `iter_mut()`, but could be made a private function instead. 